### PR TITLE
Fix #8: Licenses containg `---` are cut-off

### DIFF
--- a/.atomist/editors/AddLicenseFile.ts
+++ b/.atomist/editors/AddLicenseFile.ts
@@ -47,16 +47,19 @@ export let editor: ProjectEditor = {
         if (licenseFile == null) {
             throw Error(`Unable to find licenseFile: ${licenseFileName}`)
         }
-        let strings = licenseFile.content().split("---")
+
+        let yamlDocumentSeparator = '---'
+        let strings = licenseFile.content().split(yamlDocumentSeparator)
+        let licenseText = strings.slice(2).join(yamlDocumentSeparator)
 
         let licenseFiles: File[] = project.files().filter(isLicense)
 
         if (licenseFiles.length < 1) {
             console.log("  Adding LICENSE file...")
-            project.addFile("LICENSE", strings[2])
+            project.addFile("LICENSE", licenseText)
         } else if (licenseFiles.length == 1) {
             console.log("  Updating LICENSE file...")
-            licenseFiles[0].setContent(strings[2])
+            licenseFiles[0].setContent(licenseText)
         } else {
             throw Error(`Found too many license files wasn't sure what to do`)
         }

--- a/.atomist/tests/AddLicenseFile.rt
+++ b/.atomist/tests/AddLicenseFile.rt
@@ -44,3 +44,19 @@ then
   fileExists licenseFile
 	and fileContains licenseFile "MIT License"
 	and fileContains licenseFile "without restriction"
+
+
+scenario AddLicenseFile should add a full content of license
+
+let licenseFile = "LICENSE"
+
+given
+  Empty
+
+when
+  AddLicenseFile license_name = "mpl-2.0"
+
+then
+  fileExists licenseFile
+	and fileContains licenseFile "1. Definitions"
+	and fileContains licenseFile "--------------"


### PR DESCRIPTION
This fixes #8.